### PR TITLE
Configurable number settings

### DIFF
--- a/app/components/module-sequence/model.js
+++ b/app/components/module-sequence/model.js
@@ -76,11 +76,11 @@ export default Module.extend({
       this.addMenuSetting('Input Type', 'inputType', 'inputTypeMenuOptions', this);
 
       // todo: make config option for settings that must have a non-null numeric value
-      this.addNumberSetting('Length', 'steps.length', this);
+      this.addNumberSetting('Length', 'steps.length', this, { minValue: 1, maxValue: 64 });
       this.addNumberSetting('Input Min', 'steps.valueMin', this);
       this.addNumberSetting('Input Max', 'steps.valueMax', this);
-      this.addNumberSetting('Input Step', 'steps.valueStep', this);
-      this.addNumberSetting('Display Scale', 'displayScale', this);
+      this.addNumberSetting('Input Step', 'steps.valueStep', this, { minValue: 1 });
+      this.addNumberSetting('Display Scale', 'displayScale', this, { minValue: 1 });
 
       // create ports
       this.addEventInPort('inc', 'incrementStep', true);

--- a/app/components/module-setting/component.js
+++ b/app/components/module-setting/component.js
@@ -1,5 +1,17 @@
 import Component from '@ember/component';
+import { computed, get } from '@ember/object';
 
 export default Component.extend({
-  classNames: ['module-setting']
+  classNames: ['module-setting'],
+  attributeBindings: ['title'],
+  title: computed('setting.{minValue,maxValue,canBeEmpty}', function() {
+    let title = '';
+    if (get(this, 'setting.minValue') != null) {
+      title += `min:${get(this, 'setting.minValue')} `;
+    }
+    if (get(this, 'setting.maxValue') != null) {
+      title += `max:${get(this, 'setting.maxValue')} `;
+    }
+    return title.trim();
+  })
 });

--- a/app/components/module-setting/model.js
+++ b/app/components/module-setting/model.js
@@ -17,7 +17,6 @@ export default Model.extend({
   module: belongsTo('module', { async: false, polymorphic: true }),
   minValue: attr('number'),
   maxValue: attr('number'),
-  defaultValue: attr('number'),
 
   ready() {
     // make an alias from this.value to module.targetValue at runtime

--- a/app/components/module-setting/model.js
+++ b/app/components/module-setting/model.js
@@ -15,6 +15,9 @@ export default Model.extend({
   // a property name on the parent module to read/write
   targetValue: attr('string'),
   module: belongsTo('module', { async: false, polymorphic: true }),
+  minValue: attr('number'),
+  maxValue: attr('number'),
+  defaultValue: attr('number'),
 
   ready() {
     // make an alias from this.value to module.targetValue at runtime

--- a/app/components/module-setting/template.hbs
+++ b/app/components/module-setting/template.hbs
@@ -1,2 +1,7 @@
 <span class="setting-label">{{setting.label}}</span>
-{{value-input-number boundValue=setting.value}}
+{{value-input-number
+  boundValue=setting.value
+  defaultValue=setting.defaultValue
+  minValue=setting.minValue
+  maxValue=setting.maxValue
+}}

--- a/app/components/module-setting/template.hbs
+++ b/app/components/module-setting/template.hbs
@@ -1,7 +1,6 @@
 <span class="setting-label">{{setting.label}}</span>
 {{value-input-number
   boundValue=setting.value
-  defaultValue=setting.defaultValue
   minValue=setting.minValue
   maxValue=setting.maxValue
 }}

--- a/app/components/module-switch/model.js
+++ b/app/components/module-switch/model.js
@@ -71,7 +71,7 @@ export default Module.extend({
     if (get(this, 'isNew')) {
       set(this, 'title', this.name);
 
-      this.addNumberSetting('Inputs', 'inputPortsCount', this);
+      this.addNumberSetting('Inputs', 'inputPortsCount', this, { minValue: 1, maxValue: 8 });
 
       this.addValueInPort('switch', 'switchInPort', { canBeEmpty: true });
       this.addValueOutPort('out', 'getValue', true);

--- a/app/components/module/model.js
+++ b/app/components/module/model.js
@@ -113,9 +113,19 @@ export default Model.extend({
     return port;
   },
 
-  addNumberSetting(label, targetValue, module) {
+  addNumberSetting(label, targetValue, module, options) {
+    if (options == null) {
+      options = {};
+    }
+    if (options.canBeEmpty == null) {
+      options.canBeEmpty = false;
+    }
     let setting = this.store.createRecord('module-setting', {
       label,
+      canBeEmpty: options.canBeEmpty,
+      minValue: options.minValue,
+      maxValue: options.maxValue,
+      defaultValue: get(module, targetValue),
       targetValue,
       module
     });

--- a/app/components/module/model.js
+++ b/app/components/module/model.js
@@ -125,7 +125,6 @@ export default Model.extend({
       canBeEmpty: options.canBeEmpty,
       minValue: options.minValue,
       maxValue: options.maxValue,
-      defaultValue: get(module, targetValue),
       targetValue,
       module
     });

--- a/app/components/port-setting/template.hbs
+++ b/app/components/port-setting/template.hbs
@@ -6,7 +6,6 @@
   {{#unless port.isEnabled}}
     {{value-input-number
       boundValue=port.disabledValue
-      defaultValue=port.defaultValue
       canBeEmpty=port.canBeEmpty
       minValue=port.minValue
       maxValue=port.maxValue

--- a/app/components/value-input-array/template.hbs
+++ b/app/components/value-input-array/template.hbs
@@ -1,7 +1,7 @@
 {{#if shouldIncludeSlider}}
   <div class="value-input-array-sliders">
     {{#each array.items as |item|}}
-      {{~value-input-fader 
+      {{~value-input-fader
         item=item
         min=array.valueMin
         max=array.valueMax
@@ -14,11 +14,12 @@
 {{#if shouldIncludeNumber}}
   <div class="value-input-array-numbers">
     {{#each array.items as |item|}}
-      {{~value-array-input-number 
-        item=item 
+      {{~value-array-input-number
+        item=item
         boundValue=item.value
         min=array.valueMin
         max=array.valueMax
+        canBeEmpty=true
         step=array.valueStep
       ~}}
     {{/each}}
@@ -27,8 +28,8 @@
 {{#if isTypeButton}}
   <div class="value-input-array-buttons">
     {{#each array.items as |item|}}
-      {{~value-array-input-button 
-        item=item 
+      {{~value-array-input-button
+        item=item
         min=array.valueMin
         max=array.valueMax
       ~}}

--- a/app/components/value-input-number/component.js
+++ b/app/components/value-input-number/component.js
@@ -3,7 +3,6 @@ import { set, get, computed, observer } from '@ember/object';
 
 // from template:
 // boundValue – external, persisted value, as opposed to current <input> value
-// defaultValue
 // canBeEmpty
 // minValue
 // maxValue
@@ -41,12 +40,12 @@ export default TextField.extend({
     let value = parseInt(get(this, 'value'));
 
     if (isNaN(value)) {
-      // if new value is NaN, set boundValue to null or defaultValue,
+      // if new value is NaN, set boundValue to null or boundValue,
       // depending on canBeEmpty flag
       if (get(this, 'canBeEmpty')) {
         value = null;
       } else {
-        value = get(this, 'defaultValue');
+        value = get(this, 'boundValue');
       }
     } else {
       // if new value is a number, make sure it's within min/max
@@ -63,9 +62,6 @@ export default TextField.extend({
 
   resetValue() {
     let value = get(this, 'boundValue');
-    if (!get(this, 'canBeEmpty') && value == null) {
-      value = get(this, 'defaultValue');
-    }
     set(this, 'value', value);
   },
 


### PR DESCRIPTION
fixes #36 
- number settings can never be empty
- number settings can optionally have a minValue and maxValue
- value-in ports use defaultValue while they are enabled, if they can't be empty but the input is null
- value-in ports revert to the bound disabledValue while they are disabled, if they can't be empty and an empty or NaN number is entered
- value-in ports do not use the defaultValue at all when they are disabled